### PR TITLE
Add predict method

### DIFF
--- a/src/openea/models/basic_model.py
+++ b/src/openea/models/basic_model.py
@@ -300,18 +300,12 @@ class BasicModel:
         """
         embeds1 = tf.nn.embedding_lookup(self.ent_embeds, self.kgs.kg1.entities_list).eval(session=self.session)
         embeds2 = tf.nn.embedding_lookup(self.ent_embeds, self.kgs.kg2.entities_list).eval(session=self.session)
-        
-        print('len: ' + str(len(embeds1)))
-        print('entities_list: ' + str(len(self.kgs.kg1.entities_list)))
-        print('min: ' + str(min(self.kgs.kg1.entities_list)))
-        print('max: ' + str(max(self.kgs.kg1.entities_list)))
-        #print(self.kgs.kg1.entities_list)
-        
+
         if self.mapping_mat:
             embeds1 = np.matmul(embeds1, self.mapping_mat.eval(session=self.session))
 
         sim_mat = sim(embeds1, embeds2, metric=self.args.eval_metric, normalize=self.args.eval_norm, csls_k=0)
-        
+
         # search for correspondences which match top_k and/or min_sim_value
         matched_entities_indexes = set()
         if top_k:
@@ -332,18 +326,15 @@ class BasicModel:
             matched_entities_indexes = set(map(tuple, np.argwhere(sim_mat > min_sim_value)))
         else:
             raise ValueError("Either top_k or min_sim_value should have a value")
-        
+
         #build id to URI map:
         kg1_id_to_uri = {v: k for k, v in self.kgs.kg1.entities_id_dict.items()}
         kg2_id_to_uri = {v: k for k, v in self.kgs.kg2.entities_id_dict.items()}
-        
-        print(min(kg1_id_to_uri.keys()))
-        print(max(kg1_id_to_uri.keys()))
-        
+
         topk_neighbors_w_sim = [(kg1_id_to_uri[self.kgs.kg1.entities_list[i]],
-                    kg2_id_to_uri[self.kgs.kg2.entities_list[j]], 
+                    kg2_id_to_uri[self.kgs.kg2.entities_list[j]],
                     sim_mat[i, j]) for i, j in matched_entities_indexes]
-        
+
         if output_path is not None:
             #create dir if not existent
             directory = os.path.dirname(output_path)


### PR DESCRIPTION
Hi Zequn,

this pull request contains the predict method which I mentioned in [the issue](https://github.com/nju-websoft/OpenEA/issues/16).
It is based on your implementation of [retrieve_topk_alignment](https://github.com/nju-websoft/OpenEA/blob/e6d7806d0b7a411709eab72a9d2e437458326624/src/openea/modules/finding/alignment.py#L227).
Please carefully check if I did everything right.
I also added a new parameter which is called `min_sim_value` to further restrict the output to correspondence with a higher similarity value than the given one (this parameter is optional).

I have two more questions where I am not really sure.
1) How can the mapping_mat be incorporated? And is it necessary? Do any approaches use it?
Currently I use `embeds1 = np.matmul(embeds1, self.mapping_mat.eval(session=self.session))`. Is this correct?
2) When using the `self.kgs.kg1.entities_list`to get all entities, I saw that it [only contains entities from the relation triples](https://github.com/nju-websoft/OpenEA/blob/e6d7806d0b7a411709eab72a9d2e437458326624/src/openea/modules/load/kg.py#L63). I think it makes sense to also add entities from the subject of attribute_triples (just in case an entity has no relation but just attributes),

Maybe you can check if the result looks as expected (no switches from the indices etc).
Furthermore the `output_path` can also be removed and the result is always written to the `out_folder` as in the [save method](https://github.com/nju-websoft/OpenEA/blob/e6d7806d0b7a411709eab72a9d2e437458326624/src/openea/models/basic_model.py#L187).
Just let me kow what you think about it.

Best regards
Sven